### PR TITLE
Serve schema at /swagger.json

### DIFF
--- a/template/python3-fastapi/index.py
+++ b/template/python3-fastapi/index.py
@@ -116,3 +116,6 @@ def handle_request(
     return handler.handle(req)
 
 
+@app.get("/swagger.json", include_in_schema=False)
+async def swagger_json():
+    return app.openapi()


### PR DESCRIPTION
Most implementations of the Swagger UI (including FastAPI) serve the swagger schema at `/swagger.json`. This PR recreates that behavior, serving the schema at `GET /function/{handler.FUNCTION_NAME}/swagger.json`. 

Advantages of doing this are:

1. Developers who consume the endpoint are able to download the `swagger.json` file and use it in their favorite client code generator. 
2. Serving `swagger.json` at this location enables some of the cooler features of [Swagger Client](https://www.npmjs.com/package/swagger-client).