### PR TITLE
Update Dockerfile to fix alpine version to avoid breaking changes.

### DIFF
--- a/template/python3-fastapi/Dockerfile
+++ b/template/python3-fastapi/Dockerfile
@@ -1,5 +1,5 @@
 FROM openfaas/of-watchdog:0.7.2 as watchdog
-FROM python:3.7-alpine
+FROM python:3.7-alpine3.12
 
 COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
 RUN chmod +x /usr/bin/fwatchdog


### PR DESCRIPTION
When alpine 3.13 was released I had breaking changes when building in minikube.

In general I think it's better to have fixed version so that if it works it doesn't break.

See https://github.com/kubernetes/minikube/issues/10830 for the discussion about the original / upstream bug.